### PR TITLE
Fix filter multiple MIME types not work in android

### DIFF
--- a/android/src/main/java/com/reactnativedocumentpicker/DocumentPicker.java
+++ b/android/src/main/java/com/reactnativedocumentpicker/DocumentPicker.java
@@ -26,6 +26,8 @@ import java.io.IOException;
 import java.net.URL;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @see <a href="https://developer.android.com/guide/topics/providers/document-provider.html">android documentation</a>
@@ -54,6 +56,8 @@ public class DocumentPicker extends ReactContextBaseJavaModule implements Activi
 
     @ReactMethod
     public void show(ReadableMap args, Callback callback) {
+        String[] mimetypes;
+
         Intent intent;
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.KITKAT) {
             intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
@@ -61,11 +65,17 @@ public class DocumentPicker extends ReactContextBaseJavaModule implements Activi
             intent = new Intent(Intent.ACTION_PICK);
         }
         intent.addCategory(Intent.CATEGORY_OPENABLE);
+        intent.setType("*/*");
 
         if (!args.isNull("filetype")) {
             ReadableArray filetypes = args.getArray("filetype");
+
             if (filetypes.size() > 0) {
-                intent.setType(filetypes.getString(0));
+                mimetypes = new String[filetypes.size()];
+                for(int i=0; i<filetypes.size(); i++){
+                    mimetypes[i] = filetypes.getString(i);
+                }
+                intent.putExtra(Intent.EXTRA_MIME_TYPES, mimetypes);
             }
         }
 
@@ -211,3 +221,4 @@ public class DocumentPicker extends ReactContextBaseJavaModule implements Activi
     public void onNewIntent(Intent intent) {
     }
 }
+

--- a/android/src/main/java/com/reactnativedocumentpicker/DocumentPicker.java
+++ b/android/src/main/java/com/reactnativedocumentpicker/DocumentPicker.java
@@ -59,11 +59,7 @@ public class DocumentPicker extends ReactContextBaseJavaModule implements Activi
         String[] mimetypes;
 
         Intent intent;
-        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.KITKAT) {
-            intent = new Intent(Intent.ACTION_GET_CONTENT);
-        } else {
-            intent = new Intent(Intent.ACTION_PICK);
-        }
+        intent = new Intent(Intent.ACTION_GET_CONTENT);
         intent.addCategory(Intent.CATEGORY_OPENABLE);
         intent.setType("*/*");
 

--- a/android/src/main/java/com/reactnativedocumentpicker/DocumentPicker.java
+++ b/android/src/main/java/com/reactnativedocumentpicker/DocumentPicker.java
@@ -60,7 +60,7 @@ public class DocumentPicker extends ReactContextBaseJavaModule implements Activi
 
         Intent intent;
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.KITKAT) {
-            intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+            intent = new Intent(Intent.ACTION_GET_CONTENT);
         } else {
             intent = new Intent(Intent.ACTION_PICK);
         }


### PR DESCRIPTION
The filter multiple MIME types work in IOS but not work in android, so I fix it.

> DocumentPicker.show({filetype: [ /**multiple mime type**/ ]})


Example:
```
var docIdentifier = (Platform.OS === 'android') ? "application/msword" : "com.microsoft.word.doc"
                var docxIdentifier = (Platform.OS === 'android') ? "application/vnd.openxmlformats-officedocument.wordprocessingml.document" : "org.openxmlformats.wordprocessingml.document"
                var xlsIdentifier = (Platform.OS === 'android') ? "application/vnd.ms-excel" : "com.microsoft.excel.xls"
                var xlsxIdentifier = (Platform.OS === 'android') ? "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" : "org.openxmlformats.spreadsheetml.sheet"

                DocumentPicker.show({
                    filetype: [DocumentPickerUtil.plainText(), DocumentPickerUtil.pdf(), docIdentifier, docxIdentifier, xlsIdentifier, xlsxIdentifier],
                }, (error, url) => {
                    alert(url);
                });
```