### PR TITLE
allow open in place and opening for write

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,11 +180,15 @@ If you are on iOS and have opened the file with the *forOpen* option, then use t
 ```javascript
 
 // use the above example to get a uri (res.uri is the result from the document picker)
-var writeURL = DocumentPicker.openForWrite(res.uri)
+DocumentPicker.openForWrite(res.uri, function(error, writeUrl) {
+    if (error) {
 
-// now use [RNFS.writeFile](https://github.com/itinance/react-native-fs#writefilefilepath-string-contents-string-encoding-string-promisevoid)
+    } else {
+        // now use [RNFS.writeFile](https://github.com/itinance/react-native-fs#writefilefilepath-string-contents-string-encoding-string-promisevoid)
 
-DocumentPicker.closeForWrite(writeURL)
+        DocumentPicker.closeForWrite(writeURL)
+    }
+})
 ```
 
 Otherwise, I recommend using [https://github.com/johanneslumpe/react-native-fs](https://github.com/johanneslumpe/react-native-fs)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A React Native wrapper for:
  * Apple's ``UIDocumentMenuViewController``
- * Android's ``Intent.ACTION_OPEN_DOCUMENT`` / ``Intent.ACTION_PICK`` 
+ * Android's ``Intent.ACTION_OPEN_DOCUMENT`` / ``Intent.ACTION_PICK``
  * Windows ``Windows.Storage.Pickers``
 
 ### Installation
@@ -96,6 +96,8 @@ Use `pick` or `pickMultiple` to open a document picker for the user to select fi
   * On iOS these must be Apple "[Uniform Type Identifiers](https://developer.apple.com/library/content/documentation/Miscellaneous/Reference/UTIRef/Articles/System-DeclaredUniformTypeIdentifiers.html)"
   * If `type` is omitted it will be treated as `*/*` or `public.content`.
   * Multiple type strings are not supported on Android before KitKat (API level 19), Jellybean will fall back to `*/*` if you provide an array with more than one value.
+* **`forOpen`**: `boolean`: open the document for writing (persistent open mode)
+  * iOS only (for now)
 
 **Result:**
 
@@ -171,7 +173,21 @@ try {
 
 ## How to send it back ?
 
-I recommend using [https://github.com/johanneslumpe/react-native-fs](https://github.com/johanneslumpe/react-native-fs)
+If you are on iOS and have opened the file with the *forOpen* option, then use the following example to write to the file.
+
+(you must set the *com.apple.security.files.bookmarks.document-scope* entitlement to true)
+
+```javascript
+
+// use the above example to get a uri (res.uri is the result from the document picker)
+var writeURL = DocumentPicker.openForWrite(res.uri)
+
+// now use [RNFS.writeFile](https://github.com/itinance/react-native-fs#writefilefilepath-string-contents-string-encoding-string-promisevoid)
+
+DocumentPicker.closeForWrite(writeURL)
+```
+
+Otherwise, I recommend using [https://github.com/johanneslumpe/react-native-fs](https://github.com/johanneslumpe/react-native-fs)
 I had to modify [Uploader.m](https://gist.github.com/Elyx0/5dc53bef294b42c847f1baea7cc5e911) so it would use `NSFileCoordinator` with `NSFileCoordinatorReadingForUploading` option.
 
 I added a check for file length that would be thrown into RNFS catch block.

--- a/README.md
+++ b/README.md
@@ -175,18 +175,13 @@ try {
 
 If you are on iOS and have opened the file with the *forOpen* option, then use the following example to write to the file.
 
-(you must set the *com.apple.security.files.bookmarks.document-scope* entitlement to true)
-
 ```javascript
 
 // use the above example to get a uri (res.uri is the result from the document picker)
-DocumentPicker.openForWrite(res.uri, function(error, writeUrl) {
+var stringData = 'my awesome string'
+DocumentPicker.saveToFile(res.uri, stringData, function(error) {
     if (error) {
 
-    } else {
-        // now use [RNFS.writeFile](https://github.com/itinance/react-native-fs#writefilefilepath-string-contents-string-encoding-string-promisevoid)
-
-        DocumentPicker.closeForWrite(writeURL)
     }
 })
 ```

--- a/ios/RNDocumentPicker/RNDocumentPicker.m
+++ b/ios/RNDocumentPicker/RNDocumentPicker.m
@@ -78,25 +78,25 @@ RCT_EXPORT_METHOD(pick:(NSDictionary *)options
     [rootViewController presentViewController:documentPicker animated:YES completion:nil];
 }
 
-RCT_EXPORT_METHOD((NSString)openForWrite:(NSString)uri)
+RCT_EXPORT_METHOD(openForWrite:(NSString *)uri responder:(RCTResponseSenderBlock)respond)
 {
     NSURL *url = [NSURL fileURLWithPath:uri];
 
     NSError *bookmarkError = nil;
-    NSData *bookmark = [url bookmarkDataWithOptions: NSURLBookmarkCreationWithSecurityScope includingResourceValuesForKeys:@[url] relativeToURL:url.absoluteString error:&bookmarkError];
+    NSData *bookmark = [url bookmarkDataWithOptions: NSURLBookmarkCreationWithSecurityScope includingResourceValuesForKeys:@[url] relativeToURL:url error:&bookmarkError];
 
     if (!bookmarkError) {
         NSError *resolveError = nil;
-        NSURL *writeURL = [NSURL URLByResolvingBookmarkData:url options:NSURLBookmarkResolutionWithSecurityScope          relativeToURL:url.absoluteString bookmarkDataIsStale:false error:resolveError]
+        NSURL *writeURL = [NSURL URLByResolvingBookmarkData:bookmark options:NSURLBookmarkResolutionWithSecurityScope relativeToURL:url bookmarkDataIsStale:false error:&resolveError];
 
         if (!resolveError) {
             [writeURL startAccessingSecurityScopedResource];
-            return writeURL.absoluteString;
-        }
-    }
+            responder(@[[NSNull null], writeURL.absoluteString]);
+        } else { responder(@[resolveError]); }
+    } else { responder(@[bookmarkError]); }
 }
 
-RCT_EXPORT_METHOD(closeForWrite:(NSString)uri)
+RCT_EXPORT_METHOD(closeForWrite:(NSString *)uri)
 {
     NSURL *url = [NSURL fileURLWithPath:uri];
     [url stopAccessingSecurityScopedResource];


### PR DESCRIPTION
I'm new to Objective-C so I'm not sure about some of my code. Let me know what I need to fix. Thanks!

refs #69
on iOS, allow the document picker to open the file for writing and then save back to the file.

Here is the documentation i followed:
https://developer.apple.com/documentation/uikit/uidocumentpickerviewcontroller
https://developer.apple.com/library/content/documentation/Security/Conceptual/AppSandboxDesignGuide/AppSandboxInDepth/AppSandboxInDepth.html#//apple_ref/doc/uid/TP40011183-CH3-SW16