### PR TITLE
Allow multiple filetypes on Android

### DIFF
--- a/android/src/main/java/com/reactnativedocumentpicker/DocumentPicker.java
+++ b/android/src/main/java/com/reactnativedocumentpicker/DocumentPicker.java
@@ -64,8 +64,16 @@ public class DocumentPicker extends ReactContextBaseJavaModule implements Activi
 
         if (!args.isNull("filetype")) {
             ReadableArray filetypes = args.getArray("filetype");
-            if (filetypes.size() > 0) {
+            if (filetypes.size() == 1) {
                 intent.setType(filetypes.getString(0));
+            } else if (filetypes.size() > 1) {
+                intent.setType("*/*");
+
+                String[] extratypes = new String[filetypes.size()];
+                for (int i = 0; i < filetypes.size(); i++) {
+                  extratypes[i] = filetypes.getString(i);
+                }
+                intent.putExtra(Intent.EXTRA_MIME_TYPES, extratypes);
             }
         }
 

--- a/index.js
+++ b/index.js
@@ -24,6 +24,10 @@ class DocumentPickerUtil {
   static audio() {
     return (Platform.OS === 'android') ? "audio/*" : "public.audio";
   }
+  
+  static video() {
+    return (Platform.OS === 'android') ? "video/*" : "public.video";
+  }
 
   static pdf() {
     return (Platform.OS === 'android') ? "application/pdf" : "com.adobe.pdf";


### PR DESCRIPTION
Right now if you pass different types for `filetype` it will only allow the first array item as a file type allowed, ignoring the other ones. 

For ex: 
```
DocumentPicker.show({
  filetype: [DocumentPickerUtil.images(), DocumentPickerUtil.pdf()]
});
```

It'll allow only images to be selected.

This PR uses `Intent.EXTRA_MIME_TYPES` to allow multiples types.