### PR TITLE
Fix license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "icloud"
   ],
   "author": "Elyx0 <elyx00@gmail.com> (@Elyx0)",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/Elyx0/react-native-document-picker/issues"
   },


### PR DESCRIPTION
The package.json declares the ISC (default when you use npm init) but the library is actually MIT licensed.

Fixes #76