### PR TITLE
fix issue providers like Dropbox not show in Android

### DIFF
--- a/android/src/main/java/com/reactnativedocumentpicker/DocumentPicker.java
+++ b/android/src/main/java/com/reactnativedocumentpicker/DocumentPicker.java
@@ -56,7 +56,7 @@ public class DocumentPicker extends ReactContextBaseJavaModule implements Activi
     public void show(ReadableMap args, Callback callback) {
         Intent intent;
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.KITKAT) {
-            intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+            intent = new Intent(Intent.ACTION_GET_CONTENT);
         } else {
             intent = new Intent(Intent.ACTION_PICK);
         }


### PR DESCRIPTION
The problem is that, in the resulting menu, I get far less content providers than I expected. Only Google Drive and Downloads. Others, like Dropbox, Solid Explorer,... are not show.