### PR TITLE
Extend file meta data with filePath or cachePath for Android

### DIFF
--- a/android/src/main/java/io/github/elyx0/reactnativedocumentpicker/DocumentPickerModule.java
+++ b/android/src/main/java/io/github/elyx0/reactnativedocumentpicker/DocumentPickerModule.java
@@ -198,7 +198,7 @@ public class DocumentPickerModule extends ReactContextBaseJavaModule {
 				if (!cursor.isNull(filePathIndex)) {
 					map.putString(FIELD_FILE_PATH, cursor.getString(filePathIndex));
 				} else {
-					map.putString(FIELD_CACHE_PATH, downloadFile(uri, cursor));
+					map.putString(FIELD_CACHE_PATH, copyToCacheFolder(uri, cursor));
 				}
 
 				int displayNameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME);
@@ -227,7 +227,7 @@ public class DocumentPickerModule extends ReactContextBaseJavaModule {
 		return map;
 	}
 
-	public String downloadFile(Uri uri, Cursor cursor) {
+	public String copyToCacheFolder(Uri uri, Cursor cursor) {
 		InputStream input = null;
 		Context context = getReactApplicationContext();
 		try {

--- a/android/src/main/java/io/github/elyx0/reactnativedocumentpicker/DocumentPickerModule.java
+++ b/android/src/main/java/io/github/elyx0/reactnativedocumentpicker/DocumentPickerModule.java
@@ -23,6 +23,7 @@ import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
+import static android.provider.MediaStore.MediaColumns.DATA;
 
 /**
  * @see <a href="https://developer.android.com/guide/topics/providers/document-provider.html">android documentation</a>
@@ -45,6 +46,7 @@ public class DocumentPickerModule extends ReactContextBaseJavaModule {
 	private static final String FIELD_NAME = "name";
 	private static final String FIELD_TYPE = "type";
 	private static final String FIELD_SIZE = "size";
+	private static final String FIELD_FILE_PATH = "filepath";
 
 	private final ActivityEventListener activityEventListener = new BaseActivityEventListener() {
 		@Override
@@ -182,6 +184,11 @@ public class DocumentPickerModule extends ReactContextBaseJavaModule {
 
 		try {
 			if (cursor != null && cursor.moveToFirst()) {
+				int filePathIndex = cursor.getColumnIndex(DATA);
+				if (!cursor.isNull(filePathIndex)) {
+					map.putString(FIELD_FILE_PATH, cursor.getString(filePathIndex));
+				}
+
 				int displayNameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME);
 				if (!cursor.isNull(displayNameIndex)) {
 					map.putString(FIELD_NAME, cursor.getString(displayNameIndex));


### PR DESCRIPTION
* filePath - contains file path that can be used in RNFetchBlob, but is available only for third part apps (like Photos or File Manager)
* cachePath - copies file to app cache dir (RNFetchBlob.fs.dirs.CacheDir) and returns path for it.