### PR TITLE
Android:  Improved "type" option, re-added the "metaDataFromFile" and added "path" field.

### DIFF
--- a/android/src/main/java/io/github/elyx0/reactnativedocumentpicker/DocumentPickerModule.java
+++ b/android/src/main/java/io/github/elyx0/reactnativedocumentpicker/DocumentPickerModule.java
@@ -112,19 +112,17 @@ public class DocumentPickerModule extends ReactContextBaseJavaModule {
 		this.promise = promise;
 
 		try {
-			Intent intent = new Intent();
+			Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
 			intent.addCategory(Intent.CATEGORY_OPENABLE);
 
 			if (!args.isNull(OPTION_TYPE)) {
 				ReadableArray types = args.getArray(OPTION_TYPE);
 				if (types.size() > 1) {
 					if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-						intent.setAction(Intent.ACTION_OPEN_DOCUMENT);
 						intent.setType("*/*");
 						String[] mimeTypes = readableArrayToStringArray(types);
 						intent.putExtra(Intent.EXTRA_MIME_TYPES, mimeTypes);
 					} else {
-						intent.setAction(Intent.ACTION_GET_CONTENT);
 						intent.setType(joinReadableArray(types, "|"));
 					}
 				} else if (types.size() == 1) {

--- a/android/src/main/java/io/github/elyx0/reactnativedocumentpicker/DocumentPickerModule.java
+++ b/android/src/main/java/io/github/elyx0/reactnativedocumentpicker/DocumentPickerModule.java
@@ -30,234 +30,234 @@ import java.io.File;
  * @see <a href="https://developer.android.com/guide/topics/providers/document-provider.html">android documentation</a>
  */
 public class DocumentPickerModule extends ReactContextBaseJavaModule {
-    private static final String NAME = "RNDocumentPicker";
-    private static final int READ_REQUEST_CODE = 41;
+	private static final String NAME = "RNDocumentPicker";
+	private static final int READ_REQUEST_CODE = 41;
 
-    private static final String E_ACTIVITY_DOES_NOT_EXIST = "ACTIVITY_DOES_NOT_EXIST";
-    private static final String E_FAILED_TO_SHOW_PICKER = "FAILED_TO_SHOW_PICKER";
-    private static final String E_DOCUMENT_PICKER_CANCELED = "DOCUMENT_PICKER_CANCELED";
-    private static final String E_UNKNOWN_ACTIVITY_RESULT = "UNKNOWN_ACTIVITY_RESULT";
-    private static final String E_INVALID_DATA_RETURNED = "INVALID_DATA_RETURNED";
-    private static final String E_UNEXPECTED_EXCEPTION = "UNEXPECTED_EXCEPTION";
+	private static final String E_ACTIVITY_DOES_NOT_EXIST = "ACTIVITY_DOES_NOT_EXIST";
+	private static final String E_FAILED_TO_SHOW_PICKER = "FAILED_TO_SHOW_PICKER";
+	private static final String E_DOCUMENT_PICKER_CANCELED = "DOCUMENT_PICKER_CANCELED";
+	private static final String E_UNKNOWN_ACTIVITY_RESULT = "UNKNOWN_ACTIVITY_RESULT";
+	private static final String E_INVALID_DATA_RETURNED = "INVALID_DATA_RETURNED";
+	private static final String E_UNEXPECTED_EXCEPTION = "UNEXPECTED_EXCEPTION";
 
-    private static final String OPTION_TYPE = "type";
-    private static final String OPTION_MULIPLE = "multiple";
+	private static final String OPTION_TYPE = "type";
+	private static final String OPTION_MULIPLE = "multiple";
 
-    private static final String FIELD_URI = "uri";
-    private static final String FIELD_PATH = "path";
-    private static final String FIELD_NAME = "name";
-    private static final String FIELD_TYPE = "type";
-    private static final String FIELD_SIZE = "size";
+	private static final String FIELD_URI = "uri";
+	private static final String FIELD_PATH = "path";
+	private static final String FIELD_NAME = "name";
+	private static final String FIELD_TYPE = "type";
+	private static final String FIELD_SIZE = "size";
 
-    private final ActivityEventListener activityEventListener = new BaseActivityEventListener() {
-        @Override
-        public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data) {
-            if (requestCode == READ_REQUEST_CODE) {
-                if (promise != null) {
-                    onShowActivityResult(resultCode, data, promise);
-                    promise = null;
-                }
-            }
-        }
-    };
+	private final ActivityEventListener activityEventListener = new BaseActivityEventListener() {
+		@Override
+		public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data) {
+			if (requestCode == READ_REQUEST_CODE) {
+				if (promise != null) {
+					onShowActivityResult(resultCode, data, promise);
+					promise = null;
+				}
+			}
+		}
+	};
 
-    private String[] readableArrayToStringArray(ReadableArray readableArray) {
-        int l = readableArray.size();
-        String[] array = new String[l];
-        for (int i = 0; i < l; ++i) {
-            array[i] = readableArray.getString(i);
-        }
-        return array;
-    }
+	private String[] readableArrayToStringArray(ReadableArray readableArray) {
+		int l = readableArray.size();
+		String[] array = new String[l];
+		for (int i = 0; i < l; ++i) {
+			array[i] = readableArray.getString(i);
+		}
+		return array;
+	}
 
-    private String joinReadableArray(ReadableArray readableArray, String separator) {
-        int l = readableArray.size();
-        StringBuilder joined = new StringBuilder();
-        for (int i = 0; i < l; i++) {
-            if (joined.length() > 0) {
-                joined.append(separator);
-            }
-            joined.append(readableArray.getString(i));
-        }
-        return joined.toString();
-    }
+	private String joinReadableArray(ReadableArray readableArray, String separator) {
+		int l = readableArray.size();
+		StringBuilder joined = new StringBuilder();
+		for (int i = 0; i < l; i++) {
+			if (joined.length() > 0) {
+				joined.append(separator);
+			}
+			joined.append(readableArray.getString(i));
+		}
+		return joined.toString();
+	}
 
-    private Promise promise;
+	private Promise promise;
 
-    public DocumentPickerModule(ReactApplicationContext reactContext) {
-        super(reactContext);
-        reactContext.addActivityEventListener(activityEventListener);
-    }
+	public DocumentPickerModule(ReactApplicationContext reactContext) {
+		super(reactContext);
+		reactContext.addActivityEventListener(activityEventListener);
+	}
 
-    @Override
-    public void onCatalystInstanceDestroy() {
-        super.onCatalystInstanceDestroy();
-        getReactApplicationContext().removeActivityEventListener(activityEventListener);
-    }
+	@Override
+	public void onCatalystInstanceDestroy() {
+		super.onCatalystInstanceDestroy();
+		getReactApplicationContext().removeActivityEventListener(activityEventListener);
+	}
 
-    @Override
-    public String getName() {
-        return NAME;
-    }
+	@Override
+	public String getName() {
+		return NAME;
+	}
 
-    @ReactMethod
-    public void pick(ReadableMap args, Promise promise) {
-        Activity currentActivity = getCurrentActivity();
+	@ReactMethod
+	public void pick(ReadableMap args, Promise promise) {
+		Activity currentActivity = getCurrentActivity();
 
-        if (currentActivity == null) {
-            promise.reject(E_ACTIVITY_DOES_NOT_EXIST, "Current activity does not exist");
-            return;
-        }
+		if (currentActivity == null) {
+			promise.reject(E_ACTIVITY_DOES_NOT_EXIST, "Current activity does not exist");
+			return;
+		}
 
-        this.promise = promise;
+		this.promise = promise;
 
-        try {
-            Intent intent = new Intent();
-            intent.addCategory(Intent.CATEGORY_OPENABLE);
+		try {
+			Intent intent = new Intent();
+			intent.addCategory(Intent.CATEGORY_OPENABLE);
 
-            if (!args.isNull(OPTION_TYPE)) {
-                ReadableArray types = args.getArray(OPTION_TYPE);
-                if (types.size() > 1) {
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-                        intent.setAction(Intent.ACTION_OPEN_DOCUMENT);
-                        intent.setType("*/*");
-                        String[] mimeTypes = readableArrayToStringArray(types);
-                        intent.putExtra(Intent.EXTRA_MIME_TYPES, mimeTypes);
-                    } else {
-                        intent.setAction(Intent.ACTION_GET_CONTENT);
-                        intent.setType(joinReadableArray(types, "|"));
-                    }
-                } else if (types.size() == 1) {
-                    intent.setType(types.getString(0));
-                }
-            }
+			if (!args.isNull(OPTION_TYPE)) {
+				ReadableArray types = args.getArray(OPTION_TYPE);
+				if (types.size() > 1) {
+					if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+						intent.setAction(Intent.ACTION_OPEN_DOCUMENT);
+						intent.setType("*/*");
+						String[] mimeTypes = readableArrayToStringArray(types);
+						intent.putExtra(Intent.EXTRA_MIME_TYPES, mimeTypes);
+					} else {
+						intent.setAction(Intent.ACTION_GET_CONTENT);
+						intent.setType(joinReadableArray(types, "|"));
+					}
+				} else if (types.size() == 1) {
+					intent.setType(types.getString(0));
+				}
+			}
 
-            boolean multiple = !args.isNull(OPTION_MULIPLE) && args.getBoolean(OPTION_MULIPLE);
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
-                intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, multiple);
-            }
+			boolean multiple = !args.isNull(OPTION_MULIPLE) && args.getBoolean(OPTION_MULIPLE);
+			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+				intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, multiple);
+			}
 
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.KITKAT) {
-                intent = Intent.createChooser(intent, null);
-            }
+			if (Build.VERSION.SDK_INT < Build.VERSION_CODES.KITKAT) {
+				intent = Intent.createChooser(intent, null);
+			}
 
-            currentActivity.startActivityForResult(intent, READ_REQUEST_CODE, Bundle.EMPTY);
-        } catch (Exception e) {
-            e.printStackTrace();
-            this.promise.reject(E_FAILED_TO_SHOW_PICKER, e.getLocalizedMessage());
-            this.promise = null;
-        }
-    }
+			currentActivity.startActivityForResult(intent, READ_REQUEST_CODE, Bundle.EMPTY);
+		} catch (Exception e) {
+			e.printStackTrace();
+			this.promise.reject(E_FAILED_TO_SHOW_PICKER, e.getLocalizedMessage());
+			this.promise = null;
+		}
+	}
 
-    public void onShowActivityResult(int resultCode, Intent data, Promise promise) {
-        if (resultCode == Activity.RESULT_CANCELED) {
-            promise.reject(E_DOCUMENT_PICKER_CANCELED, "User canceled document picker");
-        } else if (resultCode == Activity.RESULT_OK) {
-            Uri uri = null;
-            ClipData clipData = null;
+	public void onShowActivityResult(int resultCode, Intent data, Promise promise) {
+		if (resultCode == Activity.RESULT_CANCELED) {
+			promise.reject(E_DOCUMENT_PICKER_CANCELED, "User canceled document picker");
+		} else if (resultCode == Activity.RESULT_OK) {
+			Uri uri = null;
+			ClipData clipData = null;
 
-            if (data != null) {
-                uri = data.getData();
-                clipData = data.getClipData();
-            }
+			if (data != null) {
+				uri = data.getData();
+				clipData = data.getClipData();
+			}
 
-            try {
-                WritableArray results = Arguments.createArray();
+			try {
+				WritableArray results = Arguments.createArray();
 
-                if (uri != null) {
-                    results.pushMap(toMapWithMetadata(uri));
-                } else if (clipData != null && clipData.getItemCount() > 0) {
-                    final int length = clipData.getItemCount();
-                    for (int i = 0; i < length; ++i) {
-                        ClipData.Item item = clipData.getItemAt(i);
-                        results.pushMap(toMapWithMetadata(item.getUri()));
-                    }
-                } else {
-                    promise.reject(E_INVALID_DATA_RETURNED, "Invalid data returned by intent");
-                    return;
-                }
+				if (uri != null) {
+					results.pushMap(toMapWithMetadata(uri));
+				} else if (clipData != null && clipData.getItemCount() > 0) {
+					final int length = clipData.getItemCount();
+					for (int i = 0; i < length; ++i) {
+						ClipData.Item item = clipData.getItemAt(i);
+						results.pushMap(toMapWithMetadata(item.getUri()));
+					}
+				} else {
+					promise.reject(E_INVALID_DATA_RETURNED, "Invalid data returned by intent");
+					return;
+				}
 
-                promise.resolve(results);
-            } catch (Exception e) {
-                promise.reject(E_UNEXPECTED_EXCEPTION, e.getLocalizedMessage(), e);
-            }
-        } else {
-            promise.reject(E_UNKNOWN_ACTIVITY_RESULT, "Unknown activity result: " + resultCode);
-        }
-    }
+				promise.resolve(results);
+			} catch (Exception e) {
+				promise.reject(E_UNEXPECTED_EXCEPTION, e.getLocalizedMessage(), e);
+			}
+		} else {
+			promise.reject(E_UNKNOWN_ACTIVITY_RESULT, "Unknown activity result: " + resultCode);
+		}
+	}
 
-    private WritableMap toMapWithMetadata(Uri uri) {
-        WritableMap map;
+	private WritableMap toMapWithMetadata(Uri uri) {
+		WritableMap map;
 
-        String utiString = uri.toString();
-        String path = uri.getPath();
-        if (utiString.startsWith("/")) {
-            map = metaDataFromFile(new File(utiString));
-        } else if (utiString.startsWith("file://")) {
-            map = metaDataFromFile(new File(path));
-        } else {
-            map = metaDataFromContentResolver(uri);
-        }
+		String utiString = uri.toString();
+		String path = uri.getPath();
+		if (utiString.startsWith("/")) {
+			map = metaDataFromFile(new File(utiString));
+		} else if (utiString.startsWith("file://")) {
+			map = metaDataFromFile(new File(path));
+		} else {
+			map = metaDataFromContentResolver(uri);
+		}
 
-        map.putString(FIELD_URI, utiString);
-        map.putString(FIELD_PATH, path);
+		map.putString(FIELD_URI, utiString);
+		map.putString(FIELD_PATH, path);
 
-        return map;
-    }
+		return map;
+	}
 
-    private WritableMap metaDataFromFile(File file) {
-        WritableMap map = Arguments.createMap();
+	private WritableMap metaDataFromFile(File file) {
+		WritableMap map = Arguments.createMap();
 
-        map.putInt(FIELD_SIZE, (int) file.length());
-        map.putString(FIELD_NAME, file.getName());
-        map.putString(FIELD_TYPE, mimeTypeFromName(file.getAbsolutePath()));
+		map.putInt(FIELD_SIZE, (int) file.length());
+		map.putString(FIELD_NAME, file.getName());
+		map.putString(FIELD_TYPE, mimeTypeFromName(file.getAbsolutePath()));
 
-        return map;
-    }
+		return map;
+	}
 
-    private static String mimeTypeFromName(String absolutePath) {
-        String extension = MimeTypeMap.getFileExtensionFromUrl(absolutePath);
-        if (extension != null) {
-            return MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
-        } else {
-            return null;
-        }
-    }
+	private static String mimeTypeFromName(String absolutePath) {
+		String extension = MimeTypeMap.getFileExtensionFromUrl(absolutePath);
+		if (extension != null) {
+			return MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
+		} else {
+			return null;
+		}
+	}
 
-    private WritableMap metaDataFromContentResolver(Uri uri) {
-        WritableMap map = Arguments.createMap();
+	private WritableMap metaDataFromContentResolver(Uri uri) {
+		WritableMap map = Arguments.createMap();
 
-        ContentResolver contentResolver = getReactApplicationContext().getContentResolver();
+		ContentResolver contentResolver = getReactApplicationContext().getContentResolver();
 
-        map.putString(FIELD_TYPE, contentResolver.getType(uri));
+		map.putString(FIELD_TYPE, contentResolver.getType(uri));
 
-        Cursor cursor = contentResolver.query(uri, null, null, null, null, null);
+		Cursor cursor = contentResolver.query(uri, null, null, null, null, null);
 
-        try {
-            if (cursor != null && cursor.moveToFirst()) {
-                int displayNameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME);
-                if (!cursor.isNull(displayNameIndex)) {
-                    map.putString(FIELD_NAME, cursor.getString(displayNameIndex));
-                }
+		try {
+			if (cursor != null && cursor.moveToFirst()) {
+				int displayNameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME);
+				if (!cursor.isNull(displayNameIndex)) {
+					map.putString(FIELD_NAME, cursor.getString(displayNameIndex));
+				}
 
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-                    int mimeIndex = cursor.getColumnIndex(DocumentsContract.Document.COLUMN_MIME_TYPE);
-                    if (!cursor.isNull(mimeIndex)) {
-                        map.putString(FIELD_TYPE, cursor.getString(mimeIndex));
-                    }
-                }
+				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+					int mimeIndex = cursor.getColumnIndex(DocumentsContract.Document.COLUMN_MIME_TYPE);
+					if (!cursor.isNull(mimeIndex)) {
+						map.putString(FIELD_TYPE, cursor.getString(mimeIndex));
+					}
+				}
 
-                int sizeIndex = cursor.getColumnIndex(OpenableColumns.SIZE);
-                if (!cursor.isNull(sizeIndex)) {
-                    map.putInt(FIELD_SIZE, cursor.getInt(sizeIndex));
-                }
-            }
-        } finally {
-            if (cursor != null) {
-                cursor.close();
-            }
-        }
+				int sizeIndex = cursor.getColumnIndex(OpenableColumns.SIZE);
+				if (!cursor.isNull(sizeIndex)) {
+					map.putInt(FIELD_SIZE, cursor.getInt(sizeIndex));
+				}
+			}
+		} finally {
+			if (cursor != null) {
+				cursor.close();
+			}
+		}
 
-        return map;
-    }
+		return map;
+	}
 }

--- a/index.js
+++ b/index.js
@@ -44,10 +44,6 @@ function pick(opts) {
     }
   });
 
-  if ( opts.type.length > 1 && Platform.OS === 'android' && Platform.Version < 19 ) {
-    console.warn(`RNDocumentPicker: Android API level ${Platform.Version} does not support multiple types, falling back to */*`);
-  }
-
   return RNDocumentPicker.pick(opts);
 }
 


### PR DESCRIPTION
## Android
- Improved "type" param to accept an array of mimetypes on olders Androids. (tested on API 16, 18 and 19 on Emulator and API 26 on real device)
- Re-added the "metaDataFromFile" method to allow to get meta for files that is not registered in ContentResolver.
- Added "path" field.