### PR TITLE
remove runtime warning about requiresMainQueueSetup

### DIFF
--- a/ios/RNDocumentPicker/RNDocumentPicker.m
+++ b/ios/RNDocumentPicker/RNDocumentPicker.m
@@ -42,6 +42,10 @@ static NSString *const FIELD_SIZE = @"size";
     return self;
 }
 
++ (BOOL)requiresMainQueueSetup {
+    return NO;
+}
+
 - (dispatch_queue_t)methodQueue
 {
     return dispatch_get_main_queue();


### PR DESCRIPTION
Removes the runtime warning, on at least RN 0.55.2 and newer.

Returns NO as init does not need to run on the main thread.