### PR TITLE
Missing symbol

### DIFF
--- a/android/src/main/java/io/github/elyx0/reactnativedocumentpicker/DocumentPickerModule.java
+++ b/android/src/main/java/io/github/elyx0/reactnativedocumentpicker/DocumentPickerModule.java
@@ -128,7 +128,7 @@ public class DocumentPickerModule extends ReactContextBaseJavaModule {
 
 			currentActivity.startActivityForResult(intent, READ_REQUEST_CODE, Bundle.EMPTY);
 		} catch (ActivityNotFoundException e) {
-			this.promise.reject(UNABLE_TO_OPEN_FILE_TYPE, e.getLocalizedMessage());
+			this.promise.reject(E_UNABLE_TO_OPEN_FILE_TYPE, e.getLocalizedMessage());
 			this.promise = null;
 		} catch (Exception e) {
 			e.printStackTrace();


### PR DESCRIPTION
Gradle started to throw error on build on a missing symbol. This fixes the typo.