### PR TITLE
[UWP] Update Newtonsoft.Json dependency

### DIFF
--- a/windows/RNDocumentPicker/project.json
+++ b/windows/RNDocumentPicker/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "dependencies": {
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.2",
-    "Newtonsoft.Json": "9.0.1",
+    "Newtonsoft.Json": "10.0.0",
     "System.Reactive.Linq": "3.1.1",
     "ZXing.Net": "0.16.0"
   },


### PR DESCRIPTION
Update project.json to point to React's version of Newtonsoft.Json

After upgrading react-native-windows to 0.57.0-rc.0 there was a conflict upstream with React itself having a newer version of this library. To remedy it I bumped the version number in the project.json. Then closed and reopened (likely restoring Nuget packages) and it fixed itself. Without this patch it refuses to compile.

That said there is some alternate way to get rid of this project.json entirely but I'm unaware of how to do this properly. So this is my simple patch in the meantime.