### PR TITLE
v3 - changed dynamic version dependency  to static

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.+'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 


### PR DESCRIPTION
This library is not building in the V3 branch
It looks like there has been a breaking change in support for dynamic version dependencies.
I haven't found much documentation about this, but i've seen in Google docs that it's not recommended

https://developer.android.com/studio/releases/gradle-plugin


This same issue is affecting other projects: 
https://github.com/react-native-community/react-native-image-picker/pull/1000
