### PR TITLE
default function param + no changing immutable opts

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ export default class DocumentPicker {
    */
   static types = PlatformTypes[Platform.OS] || Types.mimeTypes
 
-  static pick(opts = {}) {
+  static pick(opts) {
     const options = {
       ...opts,
       multiple: false
@@ -102,7 +102,7 @@ export default class DocumentPicker {
     return pick(options).then((results) => results[0]);
   }
 
-  static pickMultiple(opts = {}) {
+  static pickMultiple(opts) {
     const options = {
       ...opts,
       multiple: true

--- a/index.js
+++ b/index.js
@@ -93,16 +93,22 @@ export default class DocumentPicker {
    */
   static types = PlatformTypes[Platform.OS] || Types.mimeTypes
 
-  static pick(opts) {
-    opts = opts || {};
-    opts.multiple = false;
-    return pick(opts).then((results) => results[0]);
+  static pick(opts = {}) {
+    const options = {
+      ...opts,
+      multiple: false
+    }
+
+    return pick(options).then((results) => results[0]);
   }
 
-  static pickMultiple(opts) {
-    opts = opts || {};
-    opts.multiple = true;
-    return pick(opts);
+  static pickMultiple(opts = {}) {
+    const options = {
+      ...opts,
+      multiple: true
+    }
+
+    return pick(options);
   }
 
   static isCancel(err) {


### PR DESCRIPTION
When adding a file i got this promise rejection `You attempted to set the key 'multiple' with the value 'false' on an object that is meant to be immutable and has been frozen.` because `opts` was being modified.

I've changed so `opts` is no longer being modified. 
Also I've added so the `opts`-param  for `pick` and `pickMultiple` is now an empty object instead of overwriting it if there is no opts pressent.