### PR TITLE
Fixed file type for videos in iOS - it should be public.movie

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,9 +24,9 @@ class DocumentPickerUtil {
   static audio() {
     return (Platform.OS === 'android') ? "audio/*" : "public.audio";
   }
-  
+
   static video() {
-    return (Platform.OS === 'android') ? "video/*" : "public.video";
+    return (Platform.OS === 'android') ? "video/*" : "public.movie";
   }
 
   static pdf() {


### PR DESCRIPTION
Hey! Thanks for sharing this library with the community!

Using it I found a bit of an issue tho... I was trying to select a video on iOS and I could not, it was greyed out. I googled a bit and stumbled upon the string public.movie... Changed it in your code and the video was selectable! Unless I missed something about expected behavior this may be a nice fix.

Happy coding!