### PR TITLE
Fix breaking type definition about typescript

### DIFF
--- a/__tests__/typescript/index.test.ts
+++ b/__tests__/typescript/index.test.ts
@@ -63,3 +63,13 @@ DocumentPicker.pickMultiple({
 DocumentPicker.pickMultiple({
   type: [DocumentPicker.types.video,DocumentPicker.types.pdf, 'public.audio']
 })
+
+try {
+  throw new Error('test')
+} catch (e) {
+  if(DocumentPicker.isCancel(e)){
+
+  } else {
+
+  }
+}

--- a/__tests__/typescript/index.test.ts
+++ b/__tests__/typescript/index.test.ts
@@ -1,0 +1,11 @@
+import { DocumentPicker} from "react-native-document-picker";
+
+DocumentPicker.types.allFiles
+DocumentPicker.types.audio
+DocumentPicker.types.images
+DocumentPicker.types.plainText
+DocumentPicker.types.video
+
+DocumentPicker.pick({
+  type: [DocumentPicker.types.allFiles]
+})

--- a/__tests__/typescript/index.test.ts
+++ b/__tests__/typescript/index.test.ts
@@ -1,11 +1,65 @@
 import { DocumentPicker} from "react-native-document-picker";
 
-DocumentPicker.types.allFiles
-DocumentPicker.types.audio
-DocumentPicker.types.images
-DocumentPicker.types.plainText
-DocumentPicker.types.video
+// Option is correct about pick
 
 DocumentPicker.pick({
   type: [DocumentPicker.types.allFiles]
+})
+
+DocumentPicker.pick({
+  type: [DocumentPicker.types.audio]
+})
+
+DocumentPicker.pick({
+  type: [DocumentPicker.types.images]
+})
+
+DocumentPicker.pick({
+  type: [DocumentPicker.types.plainText]
+})
+
+DocumentPicker.pick({
+  type: [DocumentPicker.types.video]
+})
+
+DocumentPicker.pick({
+  type: [DocumentPicker.types.pdf]
+})
+
+DocumentPicker.pick({
+  type: [DocumentPicker.types.video,DocumentPicker.types.pdf, 'public.audio']
+})
+
+// Option is correct about pickMultiple
+
+DocumentPicker.pickMultiple({
+  type: [DocumentPicker.types.allFiles]
+})
+
+DocumentPicker.pickMultiple({
+  type: [DocumentPicker.types.allFiles]
+})
+
+DocumentPicker.pickMultiple({
+  type: [DocumentPicker.types.audio]
+})
+
+DocumentPicker.pickMultiple({
+  type: [DocumentPicker.types.images]
+})
+
+DocumentPicker.pickMultiple({
+  type: [DocumentPicker.types.plainText]
+})
+
+DocumentPicker.pickMultiple({
+  type: [DocumentPicker.types.video]
+})
+
+DocumentPicker.pickMultiple({
+  type: [DocumentPicker.types.pdf]
+})
+
+DocumentPicker.pickMultiple({
+  type: [DocumentPicker.types.video,DocumentPicker.types.pdf, 'public.audio']
 })

--- a/index.d.ts
+++ b/index.d.ts
@@ -49,6 +49,6 @@ declare module 'react-native-document-picker' {
     static pickMultiple<OS extends keyof PlatformTypes = Platform>(
       options: DocumentPickerOptions<OS>
     ): Promise<DocumentPickerResponse>;
-    static isCancel(err: any): void;
+    static isCancel<IError extends {code?: string}>(err?: IError): boolean;
   }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,38 @@
 declare module 'react-native-document-picker' {
-  interface DocumentPickerOptions {
-    filetype: Array<string>;
-    multiple?: Boolean;
+  type Types = {
+    mimeTypes: {
+      allFiles: '*/*',
+      audio: 'audio/*',
+      images: 'image/*',
+      plainText: 'text/plain',
+      pdf: 'application/pdf',
+      video: 'video/*',
+    },
+    utis: {
+      allFiles: 'public.content',
+      audio: 'public.audio',
+      images: 'public.image',
+      plainText: 'public.plain-text',
+      pdf: 'com.adobe.pdf',
+      video: 'public.movie',
+    },
+    extensions: {
+      allFiles: '*',
+      audio:
+        '.3g2 .3gp .aac .adt .adts .aif .aifc .aiff .asf .au .m3u .m4a .m4b .mid .midi .mp2 .mp3 .mp4 .rmi .snd .wav .wax .wma',
+      images: '.jpeg .jpg .png',
+      plainText: '.txt',
+      pdf: '.pdf',
+      video: '.mp4',
+    },
+  };
+  type PlatformTypes = {
+    android: Types['mimeTypes']
+    ios: Types['utis']
+    windows: Types['extensions']
+  };
+  interface DocumentPickerOptions<OS extends keyof PlatformTypes> {
+    type: Array<PlatformTypes[OS][keyof PlatformTypes[OS]]>
   }
   interface DocumentPickerResponse {
     uri: string;
@@ -9,12 +40,14 @@ declare module 'react-native-document-picker' {
     fileName: string;
     fileSize: string;
   }
-  export class DocumentPicker {
-    static pick(
-      options: { multiple: false } & DocumentPickerOptions
+  type Platform = 'ios' | 'android' | 'windows'
+  export class DocumentPicker<OS extends keyof PlatformTypes = Platform> {
+    static types: PlatformTypes['ios'] | PlatformTypes['android'] | PlatformTypes['windows']
+    static pick<OS extends keyof PlatformTypes = Platform>(
+      options: DocumentPickerOptions<OS>
     ): Promise<DocumentPickerResponse>;
-    static pickMultiple(
-      options: { multiple: true } & DocumentPickerOptions
+    static pickMultiple<OS extends keyof PlatformTypes = Platform>(
+      options: DocumentPickerOptions<OS>
     ): Promise<DocumentPickerResponse>;
     static isCancel(err: any): void;
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./__tests__/typescript" ,
+    "types": ["./","./node_modules"]
+  },
+  "include": ["./"]
+}


### PR DESCRIPTION
Now index.d.ts has many old breaking types.
I fixed,

- [x] filetype -> type
- [x] multiple -> disable to inpute

then I add type check test and strict type args by union literal types.