### PR TITLE
fix type by changing default export

### DIFF
--- a/__tests__/typescript/index.test.ts
+++ b/__tests__/typescript/index.test.ts
@@ -1,4 +1,4 @@
-import { DocumentPicker} from "react-native-document-picker";
+import DocumentPicker from "react-native-document-picker";
 
 // Option is correct about pick
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -41,7 +41,7 @@ declare module 'react-native-document-picker' {
     fileSize: string;
   }
   type Platform = 'ios' | 'android' | 'windows'
-  export class DocumentPicker<OS extends keyof PlatformTypes = Platform> {
+  export default class DocumentPicker<OS extends keyof PlatformTypes = Platform> {
     static types: PlatformTypes['ios'] | PlatformTypes['android'] | PlatformTypes['windows']
     static pick<OS extends keyof PlatformTypes = Platform>(
       options: DocumentPickerOptions<OS>


### PR DESCRIPTION
In v3, new exported class DocumentPicker as default. I'm sorry I missed this change and add it to fix.