### PR TITLE
Add support for specifying single or multiple document types

### DIFF
--- a/__tests__/typescript/index.test.ts
+++ b/__tests__/typescript/index.test.ts
@@ -1,7 +1,6 @@
 import DocumentPicker from "react-native-document-picker";
 
 // Option is correct about pick
-
 DocumentPicker.pick({
   type: [DocumentPicker.types.allFiles]
 })
@@ -63,6 +62,13 @@ DocumentPicker.pickMultiple({
 DocumentPicker.pickMultiple({
   type: [DocumentPicker.types.video,DocumentPicker.types.pdf, 'public.audio']
 })
+
+DocumentPicker.pick({type: 'image/jpg'});
+DocumentPicker.pick({type: 'public.png'});
+
+DocumentPicker.pick({type: ['image/jpg', 'image/jpeg', 'image/png', 'application/pdf']});
+DocumentPicker.pick({type: ['public.png', 'public.jpeg']});
+
 
 try {
   throw new Error('test')

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,14 @@
 declare module 'react-native-document-picker' {
+  type UTI = 'public.png' | 'public.jpeg' | 'com.adobe.pdf';
+  type MimeType = 'image/jpg' | 'image/jpeg' | 'image/png' | 'application/pdf';
+  type Extension = '.jpeg' | '.jpg' | '.png' | '.txt' | '.pdf';
+
+  type DocumentType = {
+    android: MimeType | MimeType[]
+    ios: UTI | UTI[]
+    windows: Extension | Extension[]
+  };
+
   type Types = {
     mimeTypes: {
       allFiles: '*/*',
@@ -32,7 +42,7 @@ declare module 'react-native-document-picker' {
     windows: Types['extensions']
   };
   interface DocumentPickerOptions<OS extends keyof PlatformTypes> {
-    type: Array<PlatformTypes[OS][keyof PlatformTypes[OS]]>
+    type: Array<PlatformTypes[OS][keyof PlatformTypes[OS]]> | DocumentType[OS]
   }
   interface DocumentPickerResponse {
     uri: string;


### PR DESCRIPTION
Based on documentation and how the library works, you are allowed to specify a single specific document type (i.e. "public.png") or an array of document types (["public.png", "public.jpeg"]). 

The previous types only allowed to pick one of the by the library predefined type groups - this adds support for picking one or more specific types instead. 

I've only added a couple of the specific document types here that we use, but adding more is easy for whoever needs them. I also added tests for this.