### PR TITLE
iOS: Use official method to get root view controller

### DIFF
--- a/ios/RNDocumentPicker/RNDocumentPicker.m
+++ b/ios/RNDocumentPicker/RNDocumentPicker.m
@@ -5,6 +5,7 @@
 #if __has_include(<React/RCTConvert.h>)
 #import <React/RCTConvert.h>
 #import <React/RCTBridge.h>
+#import <React/RCTUtils.h>
 #else // back compatibility for RN version < 0.40
 #import "RCTConvert.h"
 #import "RCTBridge.h"
@@ -72,10 +73,7 @@ RCT_EXPORT_METHOD(pick:(NSDictionary *)options
     }
 #endif
     
-    UIViewController *rootViewController = [[[[UIApplication sharedApplication]delegate] window] rootViewController];
-    while (rootViewController.presentedViewController) {
-        rootViewController = rootViewController.presentedViewController;
-    }
+    UIViewController *rootViewController = RCTPresentedViewController();
     
     [rootViewController presentViewController:documentPicker animated:YES completion:nil];
 }


### PR DESCRIPTION
The current way of obtaining the root view controller  appears to not be working in RN 0.59.10. This new approach uses an official [method](https://github.com/facebook/react-native/blob/91681016e84cdb99bd823c937762a0d9974e56fe/React/Base/RCTUtils.h#L87) provided by React Native.