### PR TITLE
fix podspec

### DIFF
--- a/react-native-document-picker.podspec
+++ b/react-native-document-picker.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.license         = package['license']
   s.homepage        = package['homepage']
   s.authors         = { 'Elyx0' => 'elyx00@gmail.com' }
-  s.source          = { :git => "https://github.com/Elyx0/react-native-document-picker" }
+  s.source          = { :git => "https://github.com/Elyx0/react-native-document-picker", :tag => "#{s.version}" }
   s.source_files    = "ios/RNDocumentPicker/*.{h,m}"
   s.platform        = :ios, "7.0"
   s.dependency        'React'


### PR DESCRIPTION
podspec should point to particular version tag - but the version tags are not present in the repo (last one I see is 2.0.0 even though npm claims 3.2.4 is the latest.) Could you push those tags to github and merge this? Thanks! I'd be interested to become a collaborator if possible, so I could help sort out some other issues. Thanks.