### PR TITLE
Add support for zip extension

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,6 +17,7 @@ declare module 'react-native-document-picker' {
       plainText: 'text/plain',
       pdf: 'application/pdf',
       video: 'video/*',
+      zip: 'application/zip',
     },
     utis: {
       allFiles: 'public.content',
@@ -25,6 +26,7 @@ declare module 'react-native-document-picker' {
       plainText: 'public.plain-text',
       pdf: 'com.adobe.pdf',
       video: 'public.movie',
+      zip: 'public.zip-archive',
     },
     extensions: {
       allFiles: '*',
@@ -34,6 +36,7 @@ declare module 'react-native-document-picker' {
       plainText: '.txt',
       pdf: '.pdf',
       video: '.mp4',
+      zip: '.zip .gz',
     },
   };
   type PlatformTypes = {

--- a/index.js
+++ b/index.js
@@ -81,6 +81,7 @@ const Types = {
     plainText: 'text/plain',
     pdf: 'application/pdf',
     video: 'video/*',
+    zip: 'application/zip'
   },
   utis: {
     allFiles: 'public.content',
@@ -89,6 +90,7 @@ const Types = {
     plainText: 'public.plain-text',
     pdf: 'com.adobe.pdf',
     video: 'public.movie',
+    zip: 'public.zip-archive',
   },
   extensions: {
     allFiles: '*',


### PR DESCRIPTION
Makes it possible to select zip files, particularly on iOS where the public.content UTI doesn't include zip archives.