### PR TITLE
Remove non existent option from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,23 +46,6 @@ The type or types of documents to allow selection of. May be an array of types a
   - If `type` is omitted it will be treated as `*/*` or `public.content`.
   - Multiple type strings are not supported on Android before KitKat (API level 19), Jellybean will fall back to `*/*` if you provide an array with more than one value.
 
-#####  `readContent`:
-
-Boolean which defaults to `false`. If `readContent` is set to true the content of the picked file/files will be read and supplied in the result object.
-
-  - Be aware that this can introduce a huge performance hit in case of big files. (The files are read completely and into the memory and encoded to base64 afterwards to add them to the result object)
-  - However reading the file directly from within the Thread which managed the picker can be necessary on Windows: Windows Apps can only read the Downloads folder and their own app folder by default and If a file is outside of these locations it cannot be acessed directly. However if the user picks the file through a file picker permissions to that file are granted implicitly.
-
-    ```
-    In addition to the default locations, an app can access additional files and folders by declaring capabilities in the app manifest (see App capability declarations), or by calling a file picker to let the user pick files and folders for the app to access (see Open files and folders with a picker).
-    ```
-
-    https://docs.microsoft.com/en-us/windows/uwp/files/file-access-permissions
-
-    Unfortunately that permission is not granted to the whole app, but only the Thread which handled the filepicker. Therefore it can be useful to read the file directly.
-
-  - You can use `react-native-fs` on Android and IOS to read the picked file.
-
 ### Result
 
 The object a `pick` Promise resolves to or the objects in the array a `pickMultiple` Promise resolves to will contain the following keys.


### PR DESCRIPTION
Remove the `readContent` option as is not used anymore