### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 A React Native wrapper for:
 
 - Apple's `UIDocumentPickerViewController`
-- Android's `Intent.ACTION_OPEN_DOCUMENT` / `Intent.ACTION_PICK`
+- Android's `Intent.ACTION_GET_CONTENT`
 - Windows `Windows.Storage.Pickers`
 
 ### Installation


### PR DESCRIPTION
We should probably update this part as since this package is no longer using `Intent.ACTION_OPEN_DOCUMENT`  nor `Intent.ACTION_PICK` since 2017

https://github.com/Elyx0/react-native-document-picker/pull/77
063fe5d7c140c6b4a5263dd5aaf22395c8768fdf